### PR TITLE
Unbound control normal.

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -4,8 +4,8 @@ local CONTROLS = _G.CONTROL_MAPPING
 -------------------------------------------------------------------------------
 
 local function GetSpeedMultiplier()
-  local fastNormal = GetSmartControlNormal(CONTROLS.MOVE_FAST)
-  local slowNormal = GetSmartControlNormal(CONTROLS.MOVE_SLOW)
+  local fastNormal = GetNormalizedControlNormal(CONTROLS.MOVE_FAST)
+  local slowNormal = GetNormalizedControlNormal(CONTROLS.MOVE_SLOW)
 
   local baseSpeed = SETTINGS.BASE_MOVE_MULTIPLIER
   local fastSpeed = 1 + ((SETTINGS.FAST_MOVE_MULTIPLIER - 1) * fastNormal)
@@ -33,13 +33,13 @@ local function UpdateCamera()
     local speedMultiplier = GetSpeedMultiplier()
 
     -- Get rotation input
-    local lookX = GetSmartControlUnboundNormal(CONTROLS.LOOK_X)
-    local lookY = GetSmartControlUnboundNormal(CONTROLS.LOOK_Y)
+    local lookX = GetNormalizedControlUnboundNormal(CONTROLS.LOOK_X)
+    local lookY = GetNormalizedControlUnboundNormal(CONTROLS.LOOK_Y)
 
     -- Get position input
-    local moveX = GetSmartControlNormal(CONTROLS.MOVE_X)
-    local moveY = GetSmartControlNormal(CONTROLS.MOVE_Y)
-    local moveZ = GetSmartControlNormal(CONTROLS.MOVE_Z)
+    local moveX = GetNormalizedControlNormal(CONTROLS.MOVE_X)
+    local moveY = GetNormalizedControlNormal(CONTROLS.MOVE_Y)
+    local moveZ = GetNormalizedControlNormal(CONTROLS.MOVE_Z)
 
     -- Calculate new rotation.
     local rotX = rot.x + (-lookY * SETTINGS.LOOK_SENSITIVITY_X)

--- a/client/main.lua
+++ b/client/main.lua
@@ -33,8 +33,8 @@ local function UpdateCamera()
     local speedMultiplier = GetSpeedMultiplier()
 
     -- Get rotation input
-    local lookX = GetSmartControlNormal(CONTROLS.LOOK_X)
-    local lookY = GetSmartControlNormal(CONTROLS.LOOK_Y)
+    local lookX = GetSmartControlUnboundNormal(CONTROLS.LOOK_X)
+    local lookY = GetSmartControlUnboundNormal(CONTROLS.LOOK_Y)
 
     -- Get position input
     local moveX = GetSmartControlNormal(CONTROLS.MOVE_X)

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -47,13 +47,23 @@ end
 
 function GetSmartControlNormal(control)
     if type(control) == 'table' then
+      local normal1 = GetDisabledControlNormal(0, control[1])
+      local normal2 = GetDisabledControlNormal(0, control[2])
+      return normal1 - normal2
+    end
+
+    return GetDisabledControlNormal(0, control)
+end
+
+function GetSmartControlUnboundNormal(control)
+    if type(control) == 'table' then
       local normal1 = GetDisabledControlUnboundNormal(0, control[1])
       local normal2 = GetDisabledControlUnboundNormal(0, control[2])
       return normal1 - normal2
     end
 
     return GetDisabledControlUnboundNormal(0, control)
-  end
+end
 
 function EulerToMatrix(rotX, rotY, rotZ)
   local radX = math.rad(rotX)

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -45,7 +45,7 @@ function IsGamepadControl()
   return not IsInputDisabled(2)
 end
 
-function GetSmartControlNormal(control)
+function GetNormalizedControlNormal(control)
     if type(control) == 'table' then
       local normal1 = GetDisabledControlNormal(0, control[1])
       local normal2 = GetDisabledControlNormal(0, control[2])
@@ -55,7 +55,7 @@ function GetSmartControlNormal(control)
     return GetDisabledControlNormal(0, control)
 end
 
-function GetSmartControlUnboundNormal(control)
+function GetNormalizedControlUnboundNormal(control)
     if type(control) == 'table' then
       local normal1 = GetDisabledControlUnboundNormal(0, control[1])
       local normal2 = GetDisabledControlUnboundNormal(0, control[2])

--- a/client/utils.lua
+++ b/client/utils.lua
@@ -47,12 +47,12 @@ end
 
 function GetSmartControlNormal(control)
     if type(control) == 'table' then
-      local normal1 = GetDisabledControlNormal(0, control[1])
-      local normal2 = GetDisabledControlNormal(0, control[2])
+      local normal1 = GetDisabledControlUnboundNormal(0, control[1])
+      local normal2 = GetDisabledControlUnboundNormal(0, control[2])
       return normal1 - normal2
     end
 
-    return GetDisabledControlNormal(0, control)
+    return GetDisabledControlUnboundNormal(0, control)
   end
 
 function EulerToMatrix(rotX, rotY, rotZ)


### PR DESCRIPTION
'Unbound' control normal getters allow for the return value to go above 1.0, useful for anything with mouse input.